### PR TITLE
Changed toc to false

### DIFF
--- a/docs/0.8.2/about/about-understrap.md
+++ b/docs/0.8.2/about/about-understrap.md
@@ -3,7 +3,7 @@ layout: docs
 title: About UnderStrap
 description: Learn more about the team maintaining UnderStrap, how and why the project started, and how to get involved.
 group: about
-# toc: true
+toc: false
 ---
 
 ## Team

--- a/docs/0.8.2/about/credits.md
+++ b/docs/0.8.2/about/credits.md
@@ -3,7 +3,7 @@ layout: docs
 title: Credits
 description: UnderStrap wouldn´t be what it is today without these great projects.
 group: about
-# toc: true
+toc: false
 ---
 
 ## Code

--- a/docs/0.8.2/changelog/index.md
+++ b/docs/0.8.2/changelog/index.md
@@ -3,7 +3,7 @@ layout: docs
 title: Changelog
 description: 
 group: changelog
-toc: true
+toc: false
 ---
 
 - **Release 0.8.2 April 11th 2018**

--- a/docs/0.8.2/development/available-gulp-tasks.md
+++ b/docs/0.8.2/development/available-gulp-tasks.md
@@ -3,7 +3,7 @@ layout: docs
 title: Available Gulp Tasks
 description: UnderStrap provides a set of gulp tasks to automate compilation and minification of stylesheets and JavaScript.
 group: development
-toc: true
+toc: false
 ---
 
 {% capture callout %}

--- a/docs/0.8.2/development/bootstrap.md
+++ b/docs/0.8.2/development/bootstrap.md
@@ -3,7 +3,7 @@ layout: docs
 title: Bootstrap
 description: Get started with Bootstrap, the world’s most popular framework for building responsive, mobile-first sites using UnderStrap.
 group: development
-toc: true
+toc: false
 ---
 
 {% capture callout %}

--- a/docs/0.8.2/development/developing-with-npm-and-gulp.md
+++ b/docs/0.8.2/development/developing-with-npm-and-gulp.md
@@ -3,7 +3,7 @@ layout: docs
 title: Developing with npm & Gulp
 description: UnderStrap uses npm as a dependency manager for packages like Bootstrap and Underscores. It also uses Gulp as a taskrunner to compile SASS code into .css, minify Javascript code etc.
 group: development
-toc: true
+toc: false
 ---
 
 ## Preparations: Install node.js and Gulp

--- a/docs/0.8.2/development/scss.md
+++ b/docs/0.8.2/development/scss.md
@@ -3,7 +3,7 @@ layout: docs
 title: SCSS
 description: UnderStrap builds its CSS using SCSS files as Source-files. You can use any SCSS Processor to generate the CSS.
 group: development
-toc: true
+toc: false
 ---
 
 ## Using SCSS with Gulp

--- a/docs/0.8.2/extend/custom-menus-and-menu-areas.md
+++ b/docs/0.8.2/extend/custom-menus-and-menu-areas.md
@@ -3,7 +3,7 @@ layout: docs
 title: Custom Menus and Menu Areas
 description: By default, UnderStrap just supports a single menu - the primary Menu located on top of the page. But yes, you can extend that to your liking!
 group: extend
-toc: true
+toc: false
 ---
 
 ## Adding another Menu Bar to the Parent Theme

--- a/docs/0.8.2/extend/custom-widget-areas-sidebars.md
+++ b/docs/0.8.2/extend/custom-widget-areas-sidebars.md
@@ -3,7 +3,7 @@ layout: docs
 title: Custom Widget Areas / Sidebars
 description: UnderStrap already supports six Widget Areas or "Sidebars". In case you need more, please follow the instructions below.
 group: extend
-toc: true
+toc: false
 ---
 
 ## Adding another Widget Area to the Parent Theme

--- a/docs/0.8.2/getting-started/child-theme.md
+++ b/docs/0.8.2/getting-started/child-theme.md
@@ -3,7 +3,7 @@ layout: docs
 title: Child Theme
 description: You may opt to build your own theme using UnderStrap as a starter theme or use it as a parent theme - and keep the parent updatable therefore - and make all your changes in a child theme.
 group: getting-started
-toc: true
+toc: false
 ---
 
 {% capture callout %}

--- a/docs/0.8.2/getting-started/customizer-options.md
+++ b/docs/0.8.2/getting-started/customizer-options.md
@@ -3,7 +3,7 @@ layout: docs
 title: Customizer Options
 description: UnderStrap´s customizer settings are pretty barebone as it´s intended to be performant and a starter theme and not a bloated multi-purpose theme like you find them in several theme-stores.
 group: getting-started
-toc: true
+toc: false
 ---
 
 ## Standard Customizer Settings

--- a/docs/0.8.2/getting-started/gulp-tasks.md
+++ b/docs/0.8.2/getting-started/gulp-tasks.md
@@ -3,6 +3,6 @@ layout: docs
 title: Gulp Tasks
 description: Get started with Bootstrap, the world's most popular framework for building responsive, mobile-first sites, with BootstrapCDN and a template starter page.
 group: getting-started
-toc: true
+toc: false
 ---
 

--- a/docs/0.8.2/getting-started/menus.md
+++ b/docs/0.8.2/getting-started/menus.md
@@ -3,7 +3,7 @@ layout: docs
 title: WordPress Menus
 description: UnderStrap supports only a primary menu with two levels, means just a single submenu level.
 group: getting-started
-toc: true
+toc: false
 ---
 
 ## Adding Icons to the Menu

--- a/docs/0.8.2/getting-started/page-templates.md
+++ b/docs/0.8.2/getting-started/page-templates.md
@@ -3,7 +3,7 @@ layout: docs
 title: Page Templates
 description: 
 group: getting-started
-toc: true
+toc: false
 ---
 
 ## Blank Template

--- a/docs/0.8.2/getting-started/theme-structure.md
+++ b/docs/0.8.2/getting-started/theme-structure.md
@@ -3,7 +3,7 @@ layout: docs
 title: Theme Structure
 description: 
 group: getting-started
-toc: true
+toc: false
 ---
 
 ## File structure

--- a/docs/0.8.2/gutenberg/index.md
+++ b/docs/0.8.2/gutenberg/index.md
@@ -3,7 +3,7 @@ layout: docs
 title: Gutenberg
 description: 
 group: gutenberg
-toc: true
+toc: false
 ---
 
 ## To be done

--- a/docs/0.8.2/how-to-update/child-theme.md
+++ b/docs/0.8.2/how-to-update/child-theme.md
@@ -3,7 +3,7 @@ layout: docs
 title: Child Theme
 description: 
 group: how-to-update
-toc: true
+toc: false
 ---
 
 ## To be done.

--- a/docs/0.8.2/how-to-update/parent-theme.md
+++ b/docs/0.8.2/how-to-update/parent-theme.md
@@ -3,7 +3,7 @@ layout: docs
 title: Parent Theme
 description: 
 group: how-to-update
-toc: true
+toc: false
 ---
 
 ## To be done.

--- a/docs/0.8.2/introduction/index.md
+++ b/docs/0.8.2/introduction/index.md
@@ -3,7 +3,7 @@ layout: docs
 title: Introduction
 description: Starter Theme + UI Framework == WordPress Theme Framework
 group: introduction
-toc: true
+toc: false
 ---
 
 The [_s theme](https://underscores.me/){:target="_blank"} is a good starting point to develop a WordPress theme. But it is “just” a raw starter theme. That means it outputs all the WordPress stuff correctly but without any layout or design. Why not add a well known and supported layout framework to have a solid, clean and responsive foundation?

--- a/docs/0.8.2/woocommerce/index.md
+++ b/docs/0.8.2/woocommerce/index.md
@@ -3,7 +3,7 @@ layout: docs
 title: WooCommerce
 description: 
 group: woocommerce
-toc: true
+toc: false
 ---
 
 ## To be done


### PR DESCRIPTION
Getting used to the system. I noticed that the `toc: true` set a third column off to the right on desktop with all the same content as the body content. Changed to `toc: false` on all documentation files. Feel free to not merge this PR if I'm not seeing the big picture. Just editing while reading.